### PR TITLE
Remove incorrect attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,15 +145,6 @@ And you'll get
 }
 ```
 
-### Attention
-
-Do not use eager loading constraints on `* to many` relations. Those queries confuse Lampager.
-
-```php
-App\Post::with('comments')->lampager() // BAD (post has many comments)
-App\Post::with('user')->lampager() // GOOD (post belongs to user)
-```
-
 ## Classes
 
 Note: See also [lampager/lampager](https://github.com/lampager/lampager).


### PR DESCRIPTION
- Eloquent does not use `join` for HasMany relations.
- Eloquent uses `join` for BelongsToMany relations, however, we can still use Lampager by overriding `Processor::field()`.