### PR TITLE
Pivot relation support

### DIFF
--- a/tests/Post.php
+++ b/tests/Post.php
@@ -18,6 +18,8 @@ class Post extends Model
 
     public $timestamps = false;
 
+    protected $hidden = ['pivot'];
+
     protected $casts = [
         'id' => 'int',
         'updated_at' => 'datetime',

--- a/tests/ProcessorTest.php
+++ b/tests/ProcessorTest.php
@@ -433,4 +433,45 @@ class ProcessorTest extends TestCase
                 ->paginate(['id' => 3, 'updated_at' => '2017-01-01 10:00:00'])
         );
     }
+
+    /**
+     * @test
+     */
+    public function testBelongsToMany()
+    {
+        $this->assertResultSame(
+            [
+                'records' => [
+                    ['id' => 1, 'updated_at' => '2017-01-01 10:00:00'],
+                    ['id' => 3, 'updated_at' => '2017-01-01 10:00:00'],
+                    ['id' => 5, 'updated_at' => '2017-01-01 10:00:00'],
+                ],
+                'has_previous' => null,
+                'previous_cursor' => null,
+                'has_next' => true,
+                'next_cursor' => ['pivot_id' => 4],
+            ],
+            Tag::find(1)->posts()->withPivot('id')
+                ->lampager()
+                ->forward()->limit(3)
+                ->orderBy('pivot_id')
+                ->seekable()
+                ->paginate()
+        );
+    }
+
+    /**
+     * @test
+     * @expectedException \Exception
+     * @expectedExceptionMessage The column `id` is not included in the pivot "pivot".
+     */
+    public function testBelongsToManyWithoutPivotKey()
+    {
+        Tag::find(1)->posts()
+            ->lampager()
+            ->forward()->limit(3)
+            ->orderBy('pivot_id')
+            ->seekable()
+            ->paginate();
+    }
 }

--- a/tests/Tag.php
+++ b/tests/Tag.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Lampager\Laravel\Tests;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class Tag
+ *
+ * @method static Tag create(array $attributes = [])
+ * @method static Tag find(int $id)
+ */
+class Tag extends Model
+{
+    protected $fillable = ['id'];
+
+    public $timestamps = false;
+
+    protected $casts = [
+        'id' => 'int',
+    ];
+
+    public function posts()
+    {
+        return $this->belongsToMany(Post::class);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -40,11 +40,21 @@ class TestCase extends BaseTestCase
             $table->increments('id');
             $table->datetime('updated_at');
         });
+        Schema::create('tags', function (Blueprint $table) {
+            $table->increments('id');
+        });
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('post_id');
+            $table->integer('tag_id');
+        });
 
         Post::create(['id' => 1, 'updated_at' => '2017-01-01 10:00:00']);
         Post::create(['id' => 3, 'updated_at' => '2017-01-01 10:00:00']);
         Post::create(['id' => 5, 'updated_at' => '2017-01-01 10:00:00']);
         Post::create(['id' => 2, 'updated_at' => '2017-01-01 11:00:00']);
         Post::create(['id' => 4, 'updated_at' => '2017-01-01 11:00:00']);
+
+        Tag::create(['id' => 1])->posts()->sync([1, 3, 5, 2, 4]);
     }
 }


### PR DESCRIPTION
The PR enables us to paginate `BelongsToMany` or `MorphToMany` relations.

```php
$tag->posts()->lampager()->orderBy('pivot_post_id')->paginate();
```

```php
$tag->posts()->withPivot('id')->lampager()->orderBy('pivot_id')->paginate();
```