### PR TITLE
Laravel Resource Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,52 @@ And you'll get
 }
 ```
 
+## Resource Collection
+
+Lampager supports Laravel's API Resources.
+
+- [Eloquent: API Resources - Laravel - The PHP Framework For Web Artisans](https://laravel.com/docs/6.x/eloquent-resources)
+
+Use helper traits on Resource and ResourceCollection.
+
+```php
+use Illuminate\Http\Resources\Json\JsonResource;
+use Lampager\Laravel\LampagerResourceTrait;
+
+class PostResource extends JsonResource
+{
+    use LampagerResourceTrait;
+}
+```
+
+```php
+use Illuminate\Http\Resources\Json\ResourceCollection;
+use Lampager\Laravel\LampagerResourceCollectionTrait;
+
+class PostResourceCollection extends ResourceCollection
+{
+    use LampagerResourceCollectionTrait;
+}
+```
+
+```php
+$posts = App\Post::lampager()
+    ->orderByDesc('id')
+    ->paginate();
+
+return new PostResourceCollection($posts);
+```
+
+```json5
+{
+  "data": [/* ... */],
+  "has_previous": false,
+  "previous_cursor": null,
+  "has_next": true,
+  "next_cursor": {/* ... */}
+}
+```
+
 ## Classes
 
 Note: See also [lampager/lampager](https://github.com/lampager/lampager).
@@ -155,6 +201,8 @@ Note: See also [lampager/lampager](https://github.com/lampager/lampager).
 | Lampager\\Laravel\\`Processor` | Class | Lampager\\`AbstractProcessor` | Processor implementation for Laravel |
 | Lampager\\Laravel\\`PaginationResult` | Class | Lampager\\`PaginationResult` | PaginationResult implementation for Laravel |
 | Lampager\\Laravel\\`MacroServiceProvider` | Class | Illuminate\\Support\\`ServiceProvider` | Enable macros chainable from QueryBuilder, ElqouentBuilder and Relation |
+| Lampager\\Laravel\\`LampagerResourceTrait` | Trait | | Support for Laravel JsonResource |
+| Lampager\\Laravel\\`LampagerResourceCollectionTrait` | Trait | | Support for Laravel ResourceCollection |
 
 `Paginator`, `Processor` and `PaginationResult` are macroable.
 

--- a/src/Http/Resources/CollectsPaginationResult.php
+++ b/src/Http/Resources/CollectsPaginationResult.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Lampager\Laravel\Http\Resources;
+
+use Illuminate\Http\Resources\CollectsResources;
+use Illuminate\Http\Resources\MissingValue;
+use Illuminate\Pagination\AbstractPaginator;
+use Lampager\Laravel\PaginationResult;
+
+/**
+ * Trait CollectsPaginationResult
+ *
+ * @mixin \Illuminate\Http\Resources\Json\ResourceCollection
+ */
+trait CollectsPaginationResult
+{
+    use CollectsResources;
+
+    /**
+     * Map the given collection resource into its individual resources.
+     *
+     * @param  mixed $resource
+     * @return mixed
+     */
+    protected function collectResource($resource)
+    {
+        if ($resource instanceof MissingValue) {
+            return $resource;
+        }
+
+        $collects = $this->collects();
+
+        $this->collection = $collects && !$resource->first() instanceof $collects
+            ? $resource->mapInto($collects)
+            : $resource->toBase();
+
+        if ($resource instanceof AbstractPaginator) {
+            $resource->setCollection($this->collection);
+            return $resource;
+        }
+        if ($resource instanceof PaginationResult) {
+            $resource->records = $this->collection;
+            return $resource;
+        }
+
+        return $this->collection;
+    }
+}

--- a/src/Http/Resources/Json/AnonymousPaginationResultAwareResourceCollection.php
+++ b/src/Http/Resources/Json/AnonymousPaginationResultAwareResourceCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lampager\Laravel\Http\Resources\Json;
+
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Lampager\Laravel\Http\Resources\CollectsPaginationResult;
+
+/**
+ * Class AnonymousPaginationResultAwareResourceCollection
+ *
+ * @mixin \Illuminate\Http\Resources\Json\JsonResource
+ */
+class AnonymousPaginationResultAwareResourceCollection extends AnonymousResourceCollection
+{
+    use MakesAnonymousPaginationResultAwareResourceCollection,
+        CollectsPaginationResult,
+        RespondsWithPaginationResult;
+}

--- a/src/Http/Resources/Json/MakesAnonymousPaginationResultAwareResourceCollection.php
+++ b/src/Http/Resources/Json/MakesAnonymousPaginationResultAwareResourceCollection.php
@@ -10,7 +10,7 @@ namespace Lampager\Laravel\Http\Resources\Json;
 trait MakesAnonymousPaginationResultAwareResourceCollection
 {
     /**
-     * Create new anonymous resource collection.
+     * Create a new anonymous resource collection.
      *
      * @param  mixed                                                       $resource
      * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection

--- a/src/Http/Resources/Json/MakesAnonymousPaginationResultAwareResourceCollection.php
+++ b/src/Http/Resources/Json/MakesAnonymousPaginationResultAwareResourceCollection.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Lampager\Laravel\Http\Resources\Json;
+
+/**
+ * Trait MakesAnonymousPaginationResultAwareResourceCollection
+ *
+ * @mixin \Illuminate\Http\Resources\Json\JsonResource
+ */
+trait MakesAnonymousPaginationResultAwareResourceCollection
+{
+    /**
+     * Create new anonymous resource collection.
+     *
+     * @param  mixed                                                       $resource
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public static function collection($resource)
+    {
+        return tap(new AnonymousPaginationResultAwareResourceCollection($resource, static::class), function ($collection) {
+            if (property_exists(static::class, 'preserveKeys')) {
+                $collection->preserveKeys = (new static([]))->preserveKeys === true;
+            }
+        });
+    }
+}

--- a/src/Http/Resources/Json/PaginationResultResourceResponse.php
+++ b/src/Http/Resources/Json/PaginationResultResourceResponse.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Lampager\Laravel\Http\Resources\Json;
+
+use Illuminate\Http\Resources\Json\PaginatedResourceResponse;
+use Illuminate\Support\Arr;
+
+/**
+ * class PaginationResultResourceResponse
+ */
+class PaginationResultResourceResponse extends PaginatedResourceResponse
+{
+    /**
+     * Add the pagination information to the response.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @return array
+     */
+    protected function paginationInformation($request)
+    {
+        return Arr::except($this->resource->resource->toArray(), 'records');
+    }
+}

--- a/src/Http/Resources/Json/RespondsWithPaginationResult.php
+++ b/src/Http/Resources/Json/RespondsWithPaginationResult.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Lampager\Laravel\Http\Resources\Json;
+
+use Illuminate\Http\Resources\Json\PaginatedResourceResponse;
+use Illuminate\Pagination\AbstractPaginator;
+use Lampager\Laravel\PaginationResult;
+
+/**
+ * Trait RespondsWithPaginationResult
+ *
+ * @mixin \Illuminate\Http\Resources\Json\ResourceCollection
+ */
+trait RespondsWithPaginationResult
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request      $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function toResponse($request)
+    {
+        if ($this->resource instanceof AbstractPaginator) {
+            return (new PaginatedResourceResponse($this))->toResponse($request);
+        }
+        if ($this->resource instanceof PaginationResult) {
+            return (new PaginationResultResourceResponse($this))->toResponse($request);
+        }
+
+        return parent::toResponse($request);
+    }
+}

--- a/src/LampagerResourceCollectionTrait.php
+++ b/src/LampagerResourceCollectionTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Lampager\Laravel;
+
+use Lampager\Laravel\Http\Resources\CollectsPaginationResult;
+use Lampager\Laravel\Http\Resources\Json\MakesAnonymousPaginationResultAwareResourceCollection;
+use Lampager\Laravel\Http\Resources\Json\RespondsWithPaginationResult;
+
+/**
+ * Trait LampagerResourceCollectionTrait
+ */
+trait LampagerResourceCollectionTrait
+{
+    use MakesAnonymousPaginationResultAwareResourceCollection,
+        CollectsPaginationResult,
+        RespondsWithPaginationResult;
+}

--- a/src/LampagerResourceTrait.php
+++ b/src/LampagerResourceTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lampager\Laravel;
+
+use Lampager\Laravel\Http\Resources\Json\MakesAnonymousPaginationResultAwareResourceCollection;
+
+/**
+ * Trait LampagerResourceTrait
+ */
+trait LampagerResourceTrait
+{
+    use MakesAnonymousPaginationResultAwareResourceCollection;
+}

--- a/tests/PostResource.php
+++ b/tests/PostResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Lampager\Laravel\Tests;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Lampager\Laravel\LampagerResourceTrait;
+
+/**
+ * Class PostResource
+ */
+class PostResource extends JsonResource
+{
+    use LampagerResourceTrait;
+
+    public $preserveKeys = true;
+
+    /**
+     * @param  \Illuminate\Http\Request $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request) + [
+            'post_resource' => true,
+        ];
+    }
+}

--- a/tests/PostResourceCollection.php
+++ b/tests/PostResourceCollection.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Lampager\Laravel\Tests;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+use Lampager\Laravel\LampagerResourceCollectionTrait;
+
+/**
+ * Class PostResourceCollection
+ */
+class PostResourceCollection extends ResourceCollection
+{
+    use LampagerResourceCollectionTrait;
+}

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Lampager\Laravel\Tests;
+
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Arr;
+
+class ResourceTest extends TestCase
+{
+    /**
+     * @param $expected
+     * @param $actual
+     */
+    protected function assertResultSame($expected, $actual)
+    {
+        $this->assertSame(
+            json_decode(json_encode($expected), true),
+            json_decode(json_encode($actual), true)
+        );
+    }
+
+    /**
+     * @return \Lampager\Laravel\PaginationResult
+     */
+    protected function getLampagerPagination()
+    {
+        return Post::lampager()
+            ->forward()->limit(3)
+            ->orderBy('updated_at')
+            ->orderBy('id')
+            ->seekable()
+            ->paginate(['id' => 3, 'updated_at' => '2017-01-01 10:00:00']);
+    }
+
+    /**
+     * @return \Illuminate\Contracts\Pagination\Paginator
+     */
+    protected function getStandardPagination()
+    {
+        return Post::query()
+            ->where('id', '>', 1)
+            ->orderBy('updated_at')
+            ->orderBy('id')
+            ->simplePaginate(3);
+    }
+
+    /**
+     * @test
+     */
+    public function testRawArrayOutput()
+    {
+        $expected = [
+            [
+                'id' => 3,
+                'updated_at' => '2017-01-01 10:00:00',
+                'post_resource' => true,
+            ],
+            [
+                'id' => 5,
+                'updated_at' => '2017-01-01 10:00:00',
+                'post_resource' => true,
+            ],
+            [
+                'id' => 2,
+                'updated_at' => '2017-01-01 11:00:00',
+                'post_resource' => true,
+            ],
+        ];
+
+        $pagination = $this->getLampagerPagination();
+        $records = $pagination->records;
+        $standardPagination = $this->getStandardPagination();
+
+        $this->assertResultSame($expected, (new PostResourceCollection($pagination))->resolve());
+        $this->assertResultSame($expected, (new PostResourceCollection($records))->resolve());
+        $this->assertResultSame($expected, (new PostResourceCollection($standardPagination))->resolve());
+    }
+
+    /**
+     * @test
+     */
+    public function testStructuredArrayOutput()
+    {
+        $expected = [
+            'data' => [
+                [
+                    'id' => 3,
+                    'updated_at' => '2017-01-01 10:00:00',
+                    'post_resource' => true,
+                ],
+                [
+                    'id' => 5,
+                    'updated_at' => '2017-01-01 10:00:00',
+                    'post_resource' => true,
+                ],
+                [
+                    'id' => 2,
+                    'updated_at' => '2017-01-01 11:00:00',
+                    'post_resource' => true,
+                ],
+            ],
+            'post_resource_collection' => true,
+        ];
+
+        $pagination = $this->getLampagerPagination();
+        $records = $pagination->records;
+        $standardPagination = $this->getStandardPagination();
+
+        $this->assertResultSame($expected, (new StructuredPostResourceCollection($pagination))->resolve());
+        $this->assertResultSame($expected, (new StructuredPostResourceCollection($records))->resolve());
+        $this->assertResultSame($expected, (new StructuredPostResourceCollection($standardPagination))->resolve());
+
+        $this->assertResultSame($expected, (new StructuredPostResourceCollection($records))
+            ->toResponse(null)->getData()
+        );
+        $this->assertResultSame($expected, (new PostResourceCollection($records))
+            ->additional(['post_resource_collection' => true])
+            ->toResponse(null)->getData()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testLampagerPaginationOutput()
+    {
+        $expected1 = [
+            'data' => [
+                [
+                    'id' => 3,
+                    'updated_at' => '2017-01-01 10:00:00',
+                    'post_resource' => true,
+                ],
+                [
+                    'id' => 5,
+                    'updated_at' => '2017-01-01 10:00:00',
+                    'post_resource' => true,
+                ],
+                [
+                    'id' => 2,
+                    'updated_at' => '2017-01-01 11:00:00',
+                    'post_resource' => true,
+                ],
+            ],
+            'post_resource_collection' => true,
+            'has_previous' => true,
+            'previous_cursor' => ['updated_at' => '2017-01-01 10:00:00', 'id' => 1],
+            'has_next' => true,
+            'next_cursor' => ['updated_at' => '2017-01-01 11:00:00', 'id' => 4],
+        ];
+        // different order
+        $expected2 = Arr::except($expected1, 'post_resource_collection') + ['post_resource_collection' => true];
+
+        $pagination = $this->getLampagerPagination();
+
+        $this->assertResultSame($expected1, (new StructuredPostResourceCollection($pagination))
+            ->toResponse(null)->getData()
+        );
+        $this->assertResultSame($expected2, (new PostResourceCollection($pagination))
+            ->additional(['post_resource_collection' => true])
+            ->toResponse(null)->getData()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testStandardPaginationOutput()
+    {
+        $expected1 = [
+            'data' => [
+                [
+                    'id' => 3,
+                    'updated_at' => '2017-01-01 10:00:00',
+                    'post_resource' => true,
+                ],
+                [
+                    'id' => 5,
+                    'updated_at' => '2017-01-01 10:00:00',
+                    'post_resource' => true,
+                ],
+                [
+                    'id' => 2,
+                    'updated_at' => '2017-01-01 11:00:00',
+                    'post_resource' => true,
+                ],
+            ],
+            'post_resource_collection' => true,
+            'links' => [
+                'first' => 'http://localhost?page=1',
+                'last' => null,
+                'prev' => null,
+                'next' => 'http://localhost?page=2',
+            ],
+            'meta' => [
+                'current_page' => 1,
+                'from' => 1,
+                'path' => 'http://localhost',
+                'per_page' => 3,
+                'to' => 3,
+            ],
+        ];
+        // different order
+        $expected2 = Arr::except($expected1, 'post_resource_collection') + ['post_resource_collection' => true];
+
+        $pagination = $this->getStandardPagination();
+
+        $this->assertResultSame($expected1, (new StructuredPostResourceCollection($pagination))
+            ->toResponse(null)->getData()
+        );
+        $this->assertResultSame($expected2, (new PostResourceCollection($pagination))
+            ->additional(['post_resource_collection' => true])
+            ->toResponse(null)->getData()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testMissingValue()
+    {
+        $expected = ['id' => 1];
+        $actual = (new TagResource(Tag::find(1)))->resolve();
+
+        $this->assertResultSame($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function testAnonymousResourceCollection()
+    {
+        $collection = PostResource::collection($this->getLampagerPagination());
+        $this->assertInstanceOf(AnonymousResourceCollection::class, $collection);
+
+        $expected = [
+            'data' => [
+                [
+                    'id' => 3,
+                    'updated_at' => '2017-01-01 10:00:00',
+                    'post_resource' => true,
+                ],
+                [
+                    'id' => 5,
+                    'updated_at' => '2017-01-01 10:00:00',
+                    'post_resource' => true,
+                ],
+                [
+                    'id' => 2,
+                    'updated_at' => '2017-01-01 11:00:00',
+                    'post_resource' => true,
+                ],
+            ],
+            'has_previous' => true,
+            'previous_cursor' => ['updated_at' => '2017-01-01 10:00:00', 'id' => 1],
+            'has_next' => true,
+            'next_cursor' => ['updated_at' => '2017-01-01 11:00:00', 'id' => 4],
+        ];
+        $this->assertResultSame($expected, $collection->toResponse(null)->getData());
+    }
+}

--- a/tests/StructuredPostResourceCollection.php
+++ b/tests/StructuredPostResourceCollection.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Lampager\Laravel\Tests;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+use Lampager\Laravel\LampagerResourceCollectionTrait;
+
+/**
+ * Class PostResourceCollection
+ */
+class StructuredPostResourceCollection extends ResourceCollection
+{
+    use LampagerResourceCollectionTrait;
+
+    public $collects = PostResource::class;
+
+    /**
+     * @param  \Illuminate\Http\Request $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            static::$wrap => parent::toArray($request),
+            'post_resource_collection' => true,
+        ];
+    }
+}

--- a/tests/TagResource.php
+++ b/tests/TagResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Lampager\Laravel\Tests;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Lampager\Laravel\LampagerResourceTrait;
+
+/**
+ * Class TagResource
+ */
+class TagResource extends JsonResource
+{
+    use LampagerResourceTrait;
+
+    /**
+     * @param  \Illuminate\Http\Request $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return array_replace(parent::toArray($request), [
+            'posts' => new PostResourceCollection($this->whenLoaded('posts')),
+        ]);
+    }
+}


### PR DESCRIPTION
Resolves #22  (by @trevorgehman)

Use helper traits on Resource and ResourceCollection.

```php
use Illuminate\Http\Resources\Json\JsonResource;
use Lampager\Laravel\LampagerResourceTrait;

class PostResource extends JsonResource
{
    use LampagerResourceTrait;
}
```

```php
use Illuminate\Http\Resources\Json\ResourceCollection;
use Lampager\Laravel\LampagerResourceCollectionTrait;

class PostResourceCollection extends ResourceCollection
{
    use LampagerResourceCollectionTrait;
}
```

```php
$posts = App\Post::lampager()
    ->orderByDesc('id')
    ->paginate();

return new PostResourceCollection($posts);
```

```json5
{
  "data": [/* ... */],
  "has_previous": false,
  "previous_cursor": null,
  "has_next": true,
  "next_cursor": {/* ... */}
}
```