### PR TITLE
Qualified Cursor Support

### DIFF
--- a/src/Processor.php
+++ b/src/Processor.php
@@ -150,15 +150,8 @@ class Processor extends AbstractProcessor
      */
     protected function dropTablePrefix(string $column)
     {
-        if (!$this->builder) {
-            return $column;
-        }
+        $segments = explode('.', $column);
 
-        // e.g.
-        //   x -> "x" in Standard SQL
-        //     -> [x] in MS SQL
-        //     -> `x` in MySQL
-        $q = $this->builder->getConnection()->getQueryGrammar()->wrap('x')[0];
-        return preg_replace("/^(?:(?:{$q}[^{$q}]*?{$q}|\w*?)\.)*?(?:{$q}([^{$q}]*){$q}|(\w*))$/", '$1$2', $column);
+        return end($segments);
     }
 }

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -45,7 +45,7 @@ class Processor extends AbstractProcessor
      */
     protected function field($row, $column)
     {
-        $column = $this->dropTablePrefix($column);
+        $column = static::dropTablePrefix($column);
         if ($this->builder instanceof BelongsToMany && strpos($column, 'pivot_') === 0) {
             return $this->pivotField($row, substr($column, 6), $this->pivotAccessor());
         }
@@ -148,7 +148,7 @@ class Processor extends AbstractProcessor
      * @param  string $column
      * @return string
      */
-    protected function dropTablePrefix(string $column)
+    protected static function dropTablePrefix(string $column)
     {
         $segments = explode('.', $column);
 

--- a/tests/MySQLGrammarTest.php
+++ b/tests/MySQLGrammarTest.php
@@ -434,7 +434,7 @@ class MySQLGrammarTest extends TestCase
     /**
      * @test
      */
-    public function testBelongsToMany()
+    public function testBelongsToManyOrderByPivot()
     {
         $cursor = ['pivot_id' => 2];
 
@@ -472,6 +472,52 @@ class MySQLGrammarTest extends TestCase
                     `post_tag`.`id` >= ?
                 )
                 order by `pivot_id` asc
+                limit 4
+            )
+        ', $builder->toSql());
+    }
+
+    /**
+     * @test
+     */
+    public function testBelongsToManyOrderBySource()
+    {
+        $cursor = ['posts.id' => 2];
+
+        $tag = new Tag();
+        $tag->id = 1;
+        $tag->exists = true;
+
+        $builder = $tag->posts()->withPivot('id')
+            ->lampager()
+            ->forward()->limit(3)
+            ->orderBy('posts.id')
+            ->seekable()
+            ->build($cursor);
+
+        $this->assertSqlEquals('
+            (
+                select * from `posts`
+                inner join `post_tag` on `posts`.`id` = `post_tag`.`post_id`
+                where `post_tag`.`tag_id` = ? AND (
+                    `posts`.`id` < ?
+                )
+                order by `posts`.`id` desc
+                limit 1
+            )
+            union all
+            (
+                select
+                    `posts`.*,
+                    `post_tag`.`tag_id` as `pivot_tag_id`,
+                    `post_tag`.`post_id` as `pivot_post_id`,
+                    `post_tag`.`id` as `pivot_id`
+                from `posts`
+                inner join `post_tag` on `posts`.`id` = `post_tag`.`post_id`
+                where `post_tag`.`tag_id` = ? AND (
+                    `posts`.`id` >= ?
+                )
+                order by `posts`.`id` asc
                 limit 4
             )
         ', $builder->toSql());

--- a/tests/ProcessorTest.php
+++ b/tests/ProcessorTest.php
@@ -2,9 +2,6 @@
 
 namespace Lampager\Laravel\Tests;
 
-use Lampager\Laravel\Paginator;
-use Lampager\Laravel\Processor;
-
 class ProcessorTest extends TestCase
 {
     /**
@@ -503,79 +500,5 @@ class ProcessorTest extends TestCase
             ->orderBy('pivot_id')
             ->seekable()
             ->paginate();
-    }
-
-    /**
-     * @test
-     */
-    public function testProcessorWithBuilderCanRetrieveUnqualifiedCursor()
-    {
-        $this->assertResultSame(
-            [
-                'records' => [
-                    ['id' => 1, 'updated_at' => '2017-01-01 10:00:00'],
-                    ['id' => 3, 'updated_at' => '2017-01-01 10:00:00'],
-                    ['id' => 5, 'updated_at' => '2017-01-01 10:00:00'],
-                ],
-                'has_previous' => null,
-                'previous_cursor' => null,
-                'has_next' => true,
-                'next_cursor' => ['updated_at' => '2017-01-01 11:00:00', 'id' => 2],
-            ],
-            (new Processor())
-                ->process(
-                    (new Paginator(null))
-                        ->forward()->limit(3)
-                        ->orderBy('updated_at')
-                        ->orderBy('id')
-                        ->seekable()
-                        ->configure(),
-                    Post::lampager()
-                        ->forward()->limit(3)
-                        ->orderBy('updated_at')
-                        ->orderBy('id')
-                        ->seekable()
-                        ->build()
-                        ->get()
-                )
-        );
-    }
-
-    /**
-     * This is a bug demonstration.
-     *
-     * @test
-     */
-    public function testProcessorWithoutBuilderFailsToRetrieveQualifiedCursor()
-    {
-        $this->assertResultSame(
-            [
-                'records' => [
-                    ['id' => 1, 'updated_at' => '2017-01-01 10:00:00'],
-                    ['id' => 3, 'updated_at' => '2017-01-01 10:00:00'],
-                    ['id' => 5, 'updated_at' => '2017-01-01 10:00:00'],
-                ],
-                'has_previous' => null,
-                'previous_cursor' => null,
-                'has_next' => true,
-                'next_cursor' => ['posts.updated_at' => null, 'posts.id' => null], // Buggy behavior
-            ],
-            (new Processor())
-                ->process(
-                    (new Paginator(null))
-                        ->forward()->limit(3)
-                        ->orderBy('posts.updated_at')
-                        ->orderBy('posts.id')
-                        ->seekable()
-                        ->configure(),
-                    Post::lampager()
-                        ->forward()->limit(3)
-                        ->orderBy('posts.updated_at')
-                        ->orderBy('posts.id')
-                        ->seekable()
-                        ->build()
-                        ->get()
-                )
-        );
     }
 }


### PR DESCRIPTION
This PR makes it possible to use qualified cursor.

```php
$tags = Tag::find(1)->posts()->withPivot('id')
    ->lampager()
    ->forward()->limit(3)
    ->orderBy('posts.id')
    ->seekable()
    ->paginate(['posts.id' => 2]);
```